### PR TITLE
fix formating bug

### DIFF
--- a/socialview-commons/src/com/hendraanggrian/appcompat/widget/HashtagArrayAdapter.kt
+++ b/socialview-commons/src/com/hendraanggrian/appcompat/widget/HashtagArrayAdapter.kt
@@ -36,10 +36,12 @@ class HashtagArrayAdapter<T : Hashtagable> @JvmOverloads constructor(
         }
         getItem(position)?.let { hashtag ->
             holder.hashtagView.text = hashtag.hashtag
-            hashtag.count?.let {
-                holder.countView.text = context.resources.getQuantityString(countPlural, it, it)
+            if (hashtag.count != null) {
+                holder.countView.visibility = View.VISIBLE
+                holder.countView.text = context.resources.getQuantityString(countPlural, hashtag.count, hashtag.count)
+            } else {
+                holder.countView.visibility = View.GONE
             }
-            older.countView.visibility = if (hashtag.count != null) View.VISIBLE else View.GONE
         }
         return view
     }

--- a/socialview-commons/src/com/hendraanggrian/appcompat/widget/HashtagArrayAdapter.kt
+++ b/socialview-commons/src/com/hendraanggrian/appcompat/widget/HashtagArrayAdapter.kt
@@ -37,8 +37,9 @@ class HashtagArrayAdapter<T : Hashtagable> @JvmOverloads constructor(
         getItem(position)?.let { hashtag ->
             holder.hashtagView.text = hashtag.hashtag
             hashtag.count?.let {
-                holder.countView.text = context.resources.getQuantityString(countPlural, it)
+                holder.countView.text = context.resources.getQuantityString(countPlural, it, it)
             }
+            older.countView.visibility = if (hashtag.count != null) View.VISIBLE else View.GONE
         }
         return view
     }


### PR DESCRIPTION
getQuantityString require twice if you want formating 
[From docs](https://developer.android.com/guide/topics/resources/string-resource#Plurals)
> When using the getQuantityString() method, you need to pass the count twice if your string includes string formatting with a number. For example, for the string %d songs found, the first count parameter selects the appropriate plural string and the second count parameter is inserted into the %d placeholder. If your plural strings do not include string formatting, you don't need to pass the third parameter to getQuantityString.

and you forgot to set the visibility if the `hashtag.count` is not null