### PR TITLE
use correct method for hyperlink click listener.

### DIFF
--- a/socialview/src/com/hendraanggrian/appcompat/widget/SocialTextView.java
+++ b/socialview/src/com/hendraanggrian/appcompat/widget/SocialTextView.java
@@ -199,7 +199,7 @@ public class SocialTextView extends AppCompatTextView implements SocialView {
      */
     @Override
     public void setOnHyperlinkClickListener(@Nullable SocialView.OnClickListener listener) {
-        impl.setOnHashtagClickListener(listener);
+        impl.setOnHyperlinkClickListener(listener);
     }
 
     /**


### PR DESCRIPTION
HashTagClickListener is called on click of hyperlink click listener, resulting in non-clickable hyperlinks. 
Use the correct method instead.