### PR TITLE
Update documentation for adding library via gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    implementation "com.hendraanggrian.appcompat:socialview-core:$version"
+    implementation "com.hendraanggrian.appcompat:socialview:$version"
 
     // auto-complete hashtag and mention
     implementation "com.hendraanggrian.appcompat:socialview-commons:$version"


### PR DESCRIPTION
Documents says we should add `implementation "com.hendraanggrian.appcompat:socialview-core:$version"` to gradle. But socialview-core cannot resolve. It need to change to just socialview like this:
`implementation "com.hendraanggrian.appcompat:socialview:$version"`